### PR TITLE
Update MDB2.php

### DIFF
--- a/MDB2.php
+++ b/MDB2.php
@@ -974,7 +974,8 @@ class MDB2_Error extends PEAR_Error
         if (null === $code) {
             $code = MDB2_ERROR;
         }
-        $this->PEAR_Error('MDB2 Error: '.MDB2::errorMessage($code), $code,
+        //$this->PEAR_Error('MDB2 Error: '.MDB2::errorMessage($code), $code,
+        $this->PEAR_Error('MDB2 Error: ' . (new MDB2)->errorMessage($code), $code,
             $mode, $level, $debuginfo);
     }
 


### PR DESCRIPTION
fix non-static method MDB2::errorMessage() should not be called statically, assuming $this from incompatible context